### PR TITLE
vtkplotter integration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,9 +44,15 @@ point sets, and meshes.
   - vtk.vtkPolyData
   - vtk.vtkStructuredGrid
   - vtk.vtkUnstructuredGrid
+  - vtk.vtkActor
+  - vtk.vtkVolume
+  - vtk.vtkAssembly
   - pyvista.PolyData
   - pyvista.StructuredGrid
   - pyvista.UnstructuredGrid
+  - vtkplotter.Actor
+  - vtkplotter.Assembly
+  - vtkplotter.Volume
 
 - Exquisite volume rendering
 - Tri-plane volume slicing
@@ -225,6 +231,7 @@ After installation, try the following examples that demonstrate how to visualize
 - `pyvista StructuredGrid <https://github.com/InsightSoftwareConsortium/itkwidgets/blob/master/examples/pyvista.StructuredGrid.ipynb>`_
 - `pyvista UnstructuredGrid <https://github.com/InsightSoftwareConsortium/itkwidgets/blob/master/examples/pyvista.UnstructuredGrid.ipynb>`_
 - `pyvista LiDAR <https://github.com/InsightSoftwareConsortium/itkwidgets/blob/master/examples/pyvistaLiDAR.ipynb>`_
+- `vtkplotter actors and volumes <https://github.com/InsightSoftwareConsortium/itkwidgets/blob/master/examples/vtkplotter.ipynb>`_
 
 or how to:
 

--- a/examples/vtkplotter.ipynb
+++ b/examples/vtkplotter.ipynb
@@ -20,7 +20,7 @@
     {
      "data": {
       "text/plain": [
-       "(Actor)0x7f3a48ba4ca8"
+       "(Actor)0x7fa08587bca8"
       ]
      },
      "execution_count": 1,
@@ -33,7 +33,7 @@
     "\n",
     "embryo = load(datadir+'embryo.slc')\n",
     "sph = Sphere(r=50).pos(10,20,30)\n",
-    "sph.pointColors(sph.getPoints()[:,2])"
+    "sph.pointColors(sph.getPoints()[:,1])"
    ]
   },
   {
@@ -54,24 +54,24 @@
       "\u001b[1m\u001b[34m      memory size: \u001b[0m\u001b[34m16 Mb\u001b[0m\n",
       "\u001b[1m\u001b[34m    scalar #bytes: \u001b[0m\u001b[34m1\u001b[0m\n",
       "\u001b[1m\u001b[34m           bounds: \u001b[0m\u001b[34mx=(0, 255)\u001b[0m\u001b[34m y=(0, 255)\u001b[0m\u001b[34m z=(0, 255)\u001b[0m\n",
-      "\u001b[1m\u001b[34m     scalar range: \u001b[0m\u001b[34m(0.0, 248.0)\u001b[0m\n",
+      "\u001b[1m\u001b[34m     scalar range: \u001b[0m\u001b[34m(0.0, 245.0)\u001b[0m\n",
       "\u001b[34m(logscale) Histogram\t(entries=100000)\n",
       "                                      4.97\n",
       "0.00  | ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆\n",
-      "21.62 | ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆\n",
-      "43.25 | ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆\n",
-      "64.88 | ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆\n",
-      "86.50 | ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆\n",
-      "108.12| ▆▆▆▆▆▆▆▆▆▆▆▆▆\n",
-      "129.75| ▆▆▆▆▆▆▆▆▆\n",
-      "151.38| ▆▆▆▆▆▆\n",
+      "19.38 | ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆\n",
+      "38.75 | ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆\n",
+      "58.12 | ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆\n",
+      "77.50 | ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆\n",
+      "96.88 | ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆\n",
+      "116.25| ▆▆▆▆▆▆▆▆▆▆▆\n",
+      "135.62| ▆▆▆▆▆▆▆\n",
       "\u001b[0m\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "(Volume)0x7f3a48ba4a68"
+       "(Volume)0x7fa08587ba68"
       ]
      },
      "execution_count": 2,
@@ -91,7 +91,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fe546fa0de2841d1b81e3ffc78e5488b",
+       "model_id": "5ae518dd6cec46e4b96cc041d4bfc7a8",
        "version_major": 2,
        "version_minor": 0
       },
@@ -106,7 +106,7 @@
    "source": [
     "from itkwidgets import view\n",
     "\n",
-    "view(actors=[embryo, sph])"
+    "view(geometries=sph.polydata(), actors=embryo)"
    ]
   },
   {

--- a/examples/vtkplotter.ipynb
+++ b/examples/vtkplotter.ipynb
@@ -14,31 +14,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(Actor)0x7fa08587bca8"
+       "(Actor)0x7fc54adf5ac8"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "from vtkplotter import *\n",
+    "from vtkplotter import load, datadir, Sphere\n",
+    "from itkwidgets import view\n",
     "\n",
     "embryo = load(datadir+'embryo.slc')\n",
+    "\n",
     "sph = Sphere(r=50).pos(10,20,30)\n",
-    "sph.pointColors(sph.getPoints()[:,1])"
+    "scals = sph.getPoints()[:,2] # scalars are z coords\n",
+    "sph.pointColors(scals)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -54,27 +57,27 @@
       "\u001b[1m\u001b[34m      memory size: \u001b[0m\u001b[34m16 Mb\u001b[0m\n",
       "\u001b[1m\u001b[34m    scalar #bytes: \u001b[0m\u001b[34m1\u001b[0m\n",
       "\u001b[1m\u001b[34m           bounds: \u001b[0m\u001b[34mx=(0, 255)\u001b[0m\u001b[34m y=(0, 255)\u001b[0m\u001b[34m z=(0, 255)\u001b[0m\n",
-      "\u001b[1m\u001b[34m     scalar range: \u001b[0m\u001b[34m(0.0, 245.0)\u001b[0m\n",
+      "\u001b[1m\u001b[34m     scalar range: \u001b[0m\u001b[34m(0.0, 197.0)\u001b[0m\n",
       "\u001b[34m(logscale) Histogram\t(entries=100000)\n",
       "                                      4.97\n",
       "0.00  | ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆\n",
-      "19.38 | ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆\n",
-      "38.75 | ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆\n",
-      "58.12 | ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆\n",
-      "77.50 | ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆\n",
-      "96.88 | ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆\n",
-      "116.25| ▆▆▆▆▆▆▆▆▆▆▆\n",
-      "135.62| ▆▆▆▆▆▆▆\n",
+      "20.00 | ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆\n",
+      "40.00 | ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆\n",
+      "60.00 | ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆\n",
+      "80.00 | ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆\n",
+      "100.00| ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆\n",
+      "120.00| ▆▆▆▆▆▆▆▆▆▆▆\n",
+      "140.00| ▆▆▆▆▆\n",
       "\u001b[0m\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "(Volume)0x7fa08587ba68"
+       "(Volume)0x7fc54adf58e8"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -85,13 +88,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5ae518dd6cec46e4b96cc041d4bfc7a8",
+       "model_id": "6464d43906bd489bb2402f17bbccf279",
        "version_major": 2,
        "version_minor": 0
       },
@@ -104,9 +107,7 @@
     }
    ],
    "source": [
-    "from itkwidgets import view\n",
-    "\n",
-    "view(geometries=sph.polydata(), actors=embryo)"
+    "view(actors=[embryo, sph])"
    ]
   },
   {

--- a/examples/vtkplotter.ipynb
+++ b/examples/vtkplotter.ipynb
@@ -1,0 +1,141 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install dependencies for this example\n",
+    "# Note: This does not include itkwidgets, itself\n",
+    "import sys\n",
+    "!{sys.executable} -m pip install vtkplotter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(Actor)0x7f3a48ba4ca8"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from vtkplotter import *\n",
+    "\n",
+    "embryo = load(datadir+'embryo.slc')\n",
+    "sph = Sphere(r=50).pos(10,20,30)\n",
+    "sph.pointColors(sph.getPoints()[:,2])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[34m_________________________________________________________________\u001b[0m\n",
+      "\u001b[7m\u001b[1m\u001b[34mvtkVolume\u001b[0m \n",
+      "\u001b[1m\u001b[34m         position: \u001b[0m\u001b[34m(0.0, 0.0, 0.0)\u001b[0m\n",
+      "\u001b[1m\u001b[34m       dimensions: \u001b[0m\u001b[34m(256, 256, 256)\u001b[0m\n",
+      "\u001b[1m\u001b[34m          spacing: \u001b[0m\u001b[34m(1.0, 1.0, 1.0)\u001b[0m\n",
+      "\u001b[1m\u001b[34m   data dimension: \u001b[0m\u001b[34m3\u001b[0m\n",
+      "\u001b[1m\u001b[34m      memory size: \u001b[0m\u001b[34m16 Mb\u001b[0m\n",
+      "\u001b[1m\u001b[34m    scalar #bytes: \u001b[0m\u001b[34m1\u001b[0m\n",
+      "\u001b[1m\u001b[34m           bounds: \u001b[0m\u001b[34mx=(0, 255)\u001b[0m\u001b[34m y=(0, 255)\u001b[0m\u001b[34m z=(0, 255)\u001b[0m\n",
+      "\u001b[1m\u001b[34m     scalar range: \u001b[0m\u001b[34m(0.0, 248.0)\u001b[0m\n",
+      "\u001b[34m(logscale) Histogram\t(entries=100000)\n",
+      "                                      4.97\n",
+      "0.00  | ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆\n",
+      "21.62 | ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆\n",
+      "43.25 | ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆\n",
+      "64.88 | ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆\n",
+      "86.50 | ▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆▆\n",
+      "108.12| ▆▆▆▆▆▆▆▆▆▆▆▆▆\n",
+      "129.75| ▆▆▆▆▆▆▆▆▆\n",
+      "151.38| ▆▆▆▆▆▆\n",
+      "\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(Volume)0x7f3a48ba4a68"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "embryo.printInfo()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fe546fa0de2841d1b81e3ffc78e5488b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Viewer(geometries=[{'vtkClass': 'vtkPolyData', 'points': {'vtkClass': 'vtkPoints', 'name': '_points', 'numberO…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from itkwidgets import view\n",
+    "\n",
+    "view(actors=[embryo, sph])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/itkwidgets/widget_viewer.py
+++ b/itkwidgets/widget_viewer.py
@@ -10,17 +10,25 @@ import functools
 import time
 
 import itk
-import vtk
 import numpy as np
 import ipywidgets as widgets
 from traitlets import CBool, CFloat, Unicode, CaselessStrEnum, TraitError, validate
 from ipydatawidgets import NDArray, array_serialization, shape_constraints
 from .trait_types import ITKImage, PointSetList, PolyDataList, itkimage_serialization, polydata_list_serialization
+
 try:
     import ipywebrtc
     ViewerParent = ipywebrtc.MediaStream
 except ImportError:
     ViewerParent = widgets.DOMWidget
+
+have_vtk = False 
+try: 
+     import vtk 
+     have_vtk = True 
+except ImportError: 
+     pass 
+
 import matplotlib
 import colorcet
 
@@ -496,7 +504,7 @@ class Viewer(ViewerParent):
             slices.insert(0, slice(index[dim], upper_index[dim] + 1))
         return tuple(slices)
 
-
+ 
 def view(image=None,
         gradient_opacity=0.22, cmap=cm.viridis, slicing_planes=False,
         select_roi=False, shadow=True, interpolation=True,
@@ -630,12 +638,11 @@ def view(image=None,
 
     # this block allows the user to pass already formed vtkActor vtkVolume objects
     actors = kwargs.pop("actors", None)
-    if actors is not None:
+    if have_vtk and actors is not None:
         if not isinstance(actors, (list, tuple)): # passing the object directly, so make it a list
             actors = [actors]
-
-        geometries, point_sets, images = [],[],[]
-        geometry_colors, geometry_opacities, point_set_colors, point_set_opacities = [],[],[],[]
+        
+        images = []
 
         for a in actors:
 

--- a/itkwidgets/widget_viewer.py
+++ b/itkwidgets/widget_viewer.py
@@ -662,11 +662,11 @@ def view(image=None,
                     tp.Update()
                     poly = tp.GetOutput()
                     if poly.GetNumberOfPolys():
-                        geometries.append(poly)
+                        geometries.insert(0, poly)
                         geometry_colors.insert(0, prop.GetColor())
                         geometry_opacities.insert(0, prop.GetOpacity())
                     else:
-                        point_sets.append(poly)
+                        point_sets.insert(0, poly)
                         point_set_colors.insert(0, prop.GetColor())
                         point_set_opacities.insert(0, prop.GetOpacity())
 
@@ -681,11 +681,11 @@ def view(image=None,
                 poly = tp.GetOutput()
                 prop = a.GetProperty()
                 if poly.GetNumberOfPolys():
-                    geometries.append(poly)
+                    geometries.insert(0, poly)
                     geometry_colors.insert(0, prop.GetColor())
                     geometry_opacities.insert(0, prop.GetOpacity())
                 else:
-                    point_sets.append(poly)
+                    point_sets.insert(0, poly)
                     point_set_colors.insert(0, prop.GetColor())
                     point_set_opacities.insert(0, prop.GetOpacity())
 

--- a/itkwidgets/widget_viewer.py
+++ b/itkwidgets/widget_viewer.py
@@ -663,12 +663,12 @@ def view(image=None,
                     poly = tp.GetOutput()
                     if poly.GetNumberOfPolys():
                         geometries.append(poly)
-                        geometry_colors.append(prop.GetColor())
-                        geometry_opacities.append(prop.GetOpacity())
+                        geometry_colors.insert(0, prop.GetColor())
+                        geometry_opacities.insert(0, prop.GetOpacity())
                     else:
                         point_sets.append(poly)
-                        point_set_colors.append(prop.GetColor())
-                        point_set_opacities.append(prop.GetOpacity())
+                        point_set_colors.insert(0, prop.GetColor())
+                        point_set_opacities.insert(0, prop.GetOpacity())
 
             elif isinstance(a, vtk.vtkActor):
                 apoly = a.GetMapper().GetInput()
@@ -682,12 +682,12 @@ def view(image=None,
                 prop = a.GetProperty()
                 if poly.GetNumberOfPolys():
                     geometries.append(poly)
-                    geometry_colors.append(prop.GetColor())
-                    geometry_opacities.append(prop.GetOpacity())
+                    geometry_colors.insert(0, prop.GetColor())
+                    geometry_opacities.insert(0, prop.GetOpacity())
                 else:
                     point_sets.append(poly)
-                    point_set_colors.append(prop.GetColor())
-                    point_set_opacities.append(prop.GetOpacity())
+                    point_set_colors.insert(0, prop.GetColor())
+                    point_set_opacities.insert(0, prop.GetOpacity())
 
             elif isinstance(a, vtk.vtkVolume):
                 images.append(a.GetMapper().GetInput())


### PR DESCRIPTION
This PR (partially) addresses #193 

- allows user to pass a list of vtkActor vtkVolume or vtkAssembly to the `view()` method using keyword `view(actors=[...])`.
- vtkplotter objects are automatically included as they inherit from the above classes
- added a usage example in `examples/vtkplotter.ipynb`

![Screenshot from 2019-09-09 18-35-47](https://user-images.githubusercontent.com/32848391/64550972-5a677300-d334-11e9-8012-51201d78d82a.png)
