### PR TITLE
Add npm badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,10 @@ itkwidgets
     :target: https://pypi.python.org/pypi/itkwidgets
     :alt: PyPI
 
+.. image:: https://img.shields.io/npm/v/itkwidgets/latest
+    :target: https://www.npmjs.com/package/itkwidgets
+    :alt: npm
+
 .. image:: https://circleci.com/gh/InsightSoftwareConsortium/itkwidgets.svg?style=shield
     :target: https://circleci.com/gh/InsightSoftwareConsortium/itkwidgets
     :alt: Build status


### PR DESCRIPTION
Could be helpful. Is it a problem that the PyPI package is of a later version than the NPM package btw? Here is an example of the added badge for the README.md file

![image](https://user-images.githubusercontent.com/3837114/67756925-2c043b00-fa3b-11e9-8f97-9968ef9149e6.png)
