### PR TITLE
BUG: Remove babel/polyfill

### DIFF
--- a/js/lib/viewer.js
+++ b/js/lib/viewer.js
@@ -1,4 +1,3 @@
-import '@babel/polyfill'
 const widgets = require('@jupyter-widgets/base')
 import {
   fixed_shape_serialization,

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -815,15 +815,6 @@
         "regexpu-core": "^4.5.4"
       }
     },
-    "@babel/polyfill": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.4.tgz",
-      "integrity": "sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==",
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.2"
-      }
-    },
     "@babel/preset-env": {
       "version": "7.4.5",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.5.tgz",
@@ -2287,11 +2278,6 @@
         "serialize-javascript": "^2.1.2",
         "webpack-log": "^2.0.0"
       }
-    },
-    "core-js": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
     },
     "core-js-compat": {
       "version": "3.1.4",
@@ -4245,11 +4231,10 @@
       }
     },
     "itk-vtk-viewer": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/itk-vtk-viewer/-/itk-vtk-viewer-9.12.0.tgz",
-      "integrity": "sha512-agcIQASC5F7CNGfKbVhri8l6OUEhBT/QS+Q0yzgrnEPr7i2yL+oG4dR3PkHdjd6f5csYH7HNHuYExMx1RRcHvg==",
+      "version": "9.12.1",
+      "resolved": "https://registry.npmjs.org/itk-vtk-viewer/-/itk-vtk-viewer-9.12.1.tgz",
+      "integrity": "sha512-0KjowEjg564BshJPC+13y3FmM7+I+Zs+1y1MrOLNPa1lc+rHPuKI4cNc4N/I2mYUHvmK6kwftaxAhuPblJJlvA==",
       "requires": {
-        "@babel/polyfill": "^7.0.0",
         "@thewtex/iconselect.js": "^2.1.2",
         "commander": "^2.17.1",
         "css-element-queries": "^1.0.2",

--- a/js/package.json
+++ b/js/package.json
@@ -53,7 +53,6 @@
     "worker-loader": "^2.0.0"
   },
   "dependencies": {
-    "@babel/polyfill": "^7.0.0",
     "@babel/runtime": "^7.2.0",
     "@jupyter-widgets/base": "^1.1 || ^2",
     "autoprefixer": "^9.4.3",
@@ -61,7 +60,7 @@
     "copy-webpack-plugin": "^5.1.1",
     "css-element-queries": "^1.0.2",
     "itk": "^10.2.0",
-    "itk-vtk-viewer": "^9.12.0",
+    "itk-vtk-viewer": "^9.12.1",
     "jupyter-dataserializers": "^2.1.0",
     "mobx": "^5.13.0",
     "vtk.js": "^13.0.0"


### PR DESCRIPTION
It should not be necessary due to Webpack/Babel transformations.

Avoid potential JupyterLab build errors.