### PR TITLE
BUG: Do not convert itk 5.1 image since it is array-like

### DIFF
--- a/itkwidgets/_transform_types.py
+++ b/itkwidgets/_transform_types.py
@@ -3,7 +3,6 @@ __all__ = ['to_itk_image', 'to_point_set', 'to_geometry']
 import itk
 import numpy as np
 
-
 def is_arraylike(arr):
     return hasattr(arr, 'shape') and \
         hasattr(arr, 'dtype') and \
@@ -160,6 +159,10 @@ def _numpy_array_to_point_set(point_set_like):
         return None
 
 def to_itk_image(image_like):
+
+    if isinstance(image_like, itk.Image):
+        return None
+
     if is_arraylike(image_like):
         array = np.asarray(image_like)
         case_use_view = array.flags['OWNDATA']


### PR DESCRIPTION
With itk 5.1.0, is_arraylike will pass on an itk.Image. to_itk_image is
currently expected to return None with an itk.Image. Keep that behavior
-- this may be changed later, but dependent code will need to be
refactored.