### PR TITLE
Require colorcet>=2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -153,7 +153,7 @@ setup_args = {
         ]),
     ],
     'install_requires': [
-        'colorcet',
+        'colorcet>=2.0.0',
         'itk-core>=5.1.0',
         'itk-filtering>=5.1.0',
         'itk-meshtopolydata>=0.6.0',


### PR DESCRIPTION
Simple fix to ensure `colorcet` is the correct version.

Resolves #308