### PR TITLE
ENH: to_itk_image does not return None with itk.Image

### DIFF
--- a/itkwidgets/_transform_types.py
+++ b/itkwidgets/_transform_types.py
@@ -161,7 +161,7 @@ def _numpy_array_to_point_set(point_set_like):
 def to_itk_image(image_like):
 
     if isinstance(image_like, itk.Image):
-        return None
+        return image_like
 
     if is_arraylike(image_like):
         array = np.asarray(image_like)
@@ -201,6 +201,8 @@ def to_itk_image(image_like):
             array = imglyb.to_numpy(image_like)
             image_from_array = itk.image_view_from_array(array)
             return image_from_array
+    elif isinstance(image_like, itk.ProcessObject):
+        return itk.output(image_like)
 
     return None
 

--- a/itkwidgets/trait_types.py
+++ b/itkwidgets/trait_types.py
@@ -34,8 +34,9 @@ class ITKImage(traitlets.TraitType):
     def validate(self, obj, value):
         self._source_object = value
 
-        image_from_array = to_itk_image(value)
-        if image_from_array:
+        if not isinstance(value, itk.Image) and not isinstance(value,
+                itk.ProcessObject):
+            image_from_array = to_itk_image(value)
             return image_from_array
 
         try:

--- a/itkwidgets/widget_checkerboard.py
+++ b/itkwidgets/widget_checkerboard.py
@@ -36,11 +36,7 @@ def checkerboard(image1, image2, pattern=3, invert=False, **viewer_kwargs):  # n
     """
 
     itk_image1 = to_itk_image(image1)
-    if not itk_image1:
-        itk_image1 = itk.output(image1)
     itk_image2 = to_itk_image(image2)
-    if not itk_image2:
-        itk_image2 = itk.output(image2)
     input1 = itk_image1
     input2 = itk_image2
 

--- a/itkwidgets/widget_compare.py
+++ b/itkwidgets/widget_compare.py
@@ -3,8 +3,6 @@ import ipywidgets as widgets
 from itkwidgets.widget_viewer import Viewer
 from traitlets import CBool
 import IPython
-from itkwidgets._transform_types import to_itk_image
-
 
 def compare(image1, image2,
             link_cmap=False, link_gradient_opacity=False,

--- a/itkwidgets/widget_line_profiler.py
+++ b/itkwidgets/widget_line_profiler.py
@@ -86,18 +86,14 @@ class LineProfiler(Viewer):
             point2 = self.point2
         if order is None:
             order = self.order
-        image_from_array = to_itk_image(image_or_array)
-        if image_from_array:
-            image_ = image_from_array
-        else:
-            image_ = image_or_array
-        image_array = itk.array_view_from_image(image_)
-        dimension = image_.GetImageDimension()
+        image = to_itk_image(image_or_array)
+        image_array = itk.array_view_from_image(image)
+        dimension = image.GetImageDimension()
         distance = np.sqrt(
             sum([(point1[ii] - point2[ii])**2 for ii in range(dimension)]))
-        index1 = tuple(image_.TransformPhysicalPointToIndex(
+        index1 = tuple(image.TransformPhysicalPointToIndex(
             tuple(point1[:dimension])))
-        index2 = tuple(image_.TransformPhysicalPointToIndex(
+        index2 = tuple(image.TransformPhysicalPointToIndex(
             tuple(point2[:dimension])))
         num_points = int(np.round(
             np.sqrt(sum([(index1[ii] - index2[ii])**2 for ii in range(dimension)])) * 2.1))


### PR DESCRIPTION
So this function can be used to generally return an itk.Image from
something that is convertible.