### PR TITLE
Update notebook-test.yml

### DIFF
--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -1,6 +1,6 @@
 name: Integration tests
 
-on: [push,pull_request]
+on: [push, pull_request]
 
 jobs:
   run:

--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -14,5 +14,4 @@ jobs:
           docker-username: thewtex
           docker-password: "${{ secrets.DOCKER_PASSWORD }}"
           docker-image-name: insighttoolkit/itkwidgets
-          notebooks:
-            - examples/3DImage.ipynb
+          notebooks: "examples/3DImage.ipynb"


### PR DESCRIPTION
Can't accept list inputs right now! We accept glob patterns though, and lists in a `treebeard.yaml` instead.

Edit: Just spotted that despite the `notebooks` field being used it's still running all notebooks. It's likely `treebeard.yaml.notebooks` is still working fine but I'm gonna get this bug turned around then ping on this PR.