### PR TITLE
Add VTK_ID_TYPE to mapper

### DIFF
--- a/itkwidgets/_transform_types.py
+++ b/itkwidgets/_transform_types.py
@@ -70,6 +70,7 @@ def _vtk_to_vtkjs(data_array):
         9: 'BigUint64Array',
         10: 'Float32Array',
         11: 'Float64Array',
+        12: 'BigInt64Array',
         16: 'BigInt64Array',
         17: 'BigUint64Array',
     }


### PR DESCRIPTION
Simple fix to add ``VTK_ID_TYPE`` to ``_vtk_data_type_to_vtkjs_type``.

Referenced:
https://vtk.org/doc/nightly/html/vtkType_8h_source.html
