### PR TITLE
ENH: Add support for PyVectorContainer functional interface

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -10,7 +10,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 colorcet
-itk-core>=5.1.0
-itk-filtering>=5.1.0
+itk-core>=5.2.0
+itk-filtering>=5.2.0
 itk-meshtopolydata>=0.6.2
 ipydatawidgets>=4.0.1
 ipywidgets>=7.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 colorcet
 itk-core>=5.2.0
 itk-filtering>=5.2.0
-itk-meshtopolydata>=0.6.2
+itk-meshtopolydata>=0.7.0
 ipydatawidgets>=4.0.1
 ipywidgets>=7.5.1
 ipympl>=0.4.1

--- a/setup.py
+++ b/setup.py
@@ -154,8 +154,8 @@ setup_args = {
     ],
     'install_requires': [
         'colorcet>=2.0.0',
-        'itk-core>=5.1.0.post2',
-        'itk-filtering>=5.1.0.post2',
+        'itk-core>=5.2.0',
+        'itk-filtering>=5.2.0',
         'itk-meshtopolydata>=0.6.2',
         'ipydatawidgets>=4.0.1',
         'ipywidgets>=7.5.1',

--- a/tests/test_transform_types.py
+++ b/tests/test_transform_types.py
@@ -41,9 +41,13 @@ def test_mesh_to_geometry():
 
     points = mesh.GetPoints()
     point_template = itk.template(points)
+    identifier_type = point_template[1][0]
     element_type = point_template[1][1]
-    point_values = itk.PyVectorContainer[element_type].array_from_vector_container(
-        points)
+    
+    if hasattr(itk, 'array_from_vector_container'):
+        point_values = itk.array_from_vector_container(points)
+    else:
+        point_values = itk.PyVectorContainer[element_type].array_from_vector_container(points)
 
     assert(geometry['vtkClass'] == 'vtkPolyData')
     assert(geometry['points']['vtkClass'] == 'vtkPoints')
@@ -121,9 +125,13 @@ def test_vtkjs_to_zarr():
 
     points = mesh.GetPoints()
     point_template = itk.template(points)
+    identifier_type = point_template[1][0]
     element_type = point_template[1][1]
-    point_values = itk.PyVectorContainer[element_type].array_from_vector_container(
-        points)
+    
+    if hasattr(itk, 'array_from_vector_container'):
+        point_values = itk.array_from_vector_container(points)
+    else:
+        point_values = itk.PyVectorContainer[element_type].array_from_vector_container(points)
 
     assert(geometry['vtkClass'] == 'vtkPolyData')
     assert(geometry['points']['vtkClass'] == 'vtkPoints')


### PR DESCRIPTION
ITK was recently updated to introduce the functional interface `array_from_vector_container` and expand the template parameter list for `PyVectorContainer` to match `VectorContainer`, to be included in the next release candidate. This PR adds support for the functional interface while continuing to support previous wrappings for `PyVectorContainer`. Changes are tested and verified against both ITK 5.2rc03 and the `master` branch.

(@thewtex )