### PR TITLE
Update for ITK 5.2

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -10,7 +10,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/itkwidgets/_transform_types.py
+++ b/itkwidgets/_transform_types.py
@@ -313,13 +313,14 @@ def to_point_set(point_set_like):  # noqa: C901
         point_set = {'vtkClass': 'vtkPolyData'}
 
         points = itk_polydata.GetPoints()
+        
         point_template = itk.template(points)
         element_type = point_template[1][1]
+        
         # todo: test array_view here and below
-        point_values = itk.PyVectorContainer[element_type].array_from_vector_container(
-            points)
-        if len(
-                point_values.shape) > 1 and point_values.shape[1] == 2 or point_values.shape[1] == 3:
+        point_values = itk.array_from_vector_container(points)
+
+        if len(point_values.shape) > 1 and point_values.shape[1] == 2 or point_values.shape[1] == 3:
             if point_values.shape[1] == 2:
                 point_values = np.hstack(
                     (point_values, -5.0e-6 * np.ones((point_values.shape[0], 1)))).astype(np.float32)
@@ -334,10 +335,13 @@ def to_point_set(point_set_like):  # noqa: C901
 
         itk_point_data = itk_polydata.GetPointData()
         if itk_point_data and itk_point_data.Size():
-            pixel_type = itk.template(itk_polydata)[1][0]
-            data_type, number_of_components = _itk_pixel_to_vtkjs_type_components[pixel_type]
-            data = itk.PyVectorContainer[pixel_type].array_from_vector_container(
-                itk_point_data)
+            point_data_template = itk.template(itk_point_data)
+            element_type = point_data_template[1][1]
+
+            # Make use of functional interface if available
+            data = itk.array_from_vector_container(itk_point_data)
+
+            data_type, number_of_components = _itk_pixel_to_vtkjs_type_components[element_type]
             point_data = {
                 "vtkClass": "vtkDataSetAttributes",
                 "activeScalars": 0,
@@ -423,13 +427,15 @@ def to_geometry(geometry_like):  # noqa: C901
         itk_polydata = itk.mesh_to_poly_data_filter(geometry_like)
 
         geometry = {'vtkClass': 'vtkPolyData'}
-
+        
         points = itk_polydata.GetPoints()
         point_template = itk.template(points)
         element_type = point_template[1][1]
+        
         # todo: test array_view here and below
-        point_values = itk.PyVectorContainer[element_type].array_from_vector_container(
-            points)
+        # Make use of functional interface if available
+        point_values = itk.array_from_vector_container(points)
+
         if len(
                 point_values.shape) > 1 and point_values.shape[1] == 2 or point_values.shape[1] == 3:
             if point_values.shape[1] == 2:
@@ -451,8 +457,8 @@ def to_geometry(geometry_like):  # noqa: C901
         for cell_type, itk_cells in [('verts', itk_verts), ('lines', itk_lines),
                                      ('polys', itk_polys), ('strips', itk_strips)]:
             if itk_cells.Size():
-                data = itk.PyVectorContainer[itk.UI].array_from_vector_container(
-                    itk_cells)
+                # Make use of functional interface if available
+                data = itk.array_from_vector_container(itk_cells)
                 cells = {'vtkClass': 'vtkCellArray',
                          'name': '_' + cell_type,
                          'numberOfComponents': 1,
@@ -460,13 +466,18 @@ def to_geometry(geometry_like):  # noqa: C901
                          'dataType': 'Uint32Array',
                          'values': data}
                 geometry[cell_type] = cells
-
+            
         itk_point_data = itk_polydata.GetPointData()
         if itk_point_data and itk_point_data.Size():
-            pixel_type = itk.template(itk_polydata)[1][0]
-            data_type, number_of_components = _itk_pixel_to_vtkjs_type_components[pixel_type]
-            data = itk.PyVectorContainer[pixel_type].array_from_vector_container(
-                itk_point_data)
+            
+            # Template parameter list [identifier_type, element_type]
+            point_data_template = itk.template(itk_point_data)
+            element_type = point_data_template[1][1]
+
+            # Make use of functional interface if available
+            data = itk.array_from_vector_container(itk_point_data)
+
+            data_type, number_of_components = _itk_pixel_to_vtkjs_type_components[element_type]
             point_data = {
                 "vtkClass": "vtkDataSetAttributes",
                 "activeScalars": 0,
@@ -483,10 +494,12 @@ def to_geometry(geometry_like):  # noqa: C901
             geometry['pointData'] = point_data
         itk_cell_data = itk_polydata.GetCellData()
         if itk_cell_data and itk_cell_data.Size():
-            pixel_type = itk.template(itk_polydata)[1][0]
-            data_type, number_of_components = _itk_pixel_to_vtkjs_type_components[pixel_type]
-            data = itk.PyVectorContainer[pixel_type].array_from_vector_container(
-                itk_cell_data)
+            point_data_template = itk.template(itk_point_data)
+            element_type = point_data_template[1][1]
+
+            data = itk.array_from_vector_container(itk_cell_data)
+
+            data_type, number_of_components = _itk_pixel_to_vtkjs_type_components[element_type]
             cell_data = {
                 "vtkClass": "vtkDataSetAttributes",
                 "activeScalars": 0,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 colorcet
-itk-core>=5.1.0
-itk-filtering>=5.1.0
-itk-meshtopolydata>=0.6.2
+itk-core>=5.2.0
+itk-filtering>=5.2.0
+itk-meshtopolydata>=0.7.0
 ipydatawidgets>=4.0.1
 ipywidgets>=7.5.1
 ipympl>=0.4.1

--- a/setup.py
+++ b/setup.py
@@ -154,8 +154,8 @@ setup_args = {
     ],
     'install_requires': [
         'colorcet>=2.0.0',
-        'itk-core>=5.1.0.post2',
-        'itk-filtering>=5.1.0.post2',
+        'itk-core>=5.2.0',
+        'itk-filtering>=5.2.0',
         'itk-meshtopolydata>=0.6.2',
         'ipydatawidgets>=4.0.1',
         'ipywidgets>=7.5.1',

--- a/tests/test_transform_types.py
+++ b/tests/test_transform_types.py
@@ -41,9 +41,10 @@ def test_mesh_to_geometry():
 
     points = mesh.GetPoints()
     point_template = itk.template(points)
+    identifier_type = point_template[1][0]
     element_type = point_template[1][1]
-    point_values = itk.PyVectorContainer[element_type].array_from_vector_container(
-        points)
+    
+    point_values = itk.array_from_vector_container(points)
 
     assert(geometry['vtkClass'] == 'vtkPolyData')
     assert(geometry['points']['vtkClass'] == 'vtkPoints')
@@ -121,9 +122,10 @@ def test_vtkjs_to_zarr():
 
     points = mesh.GetPoints()
     point_template = itk.template(points)
+    identifier_type = point_template[1][0]
     element_type = point_template[1][1]
-    point_values = itk.PyVectorContainer[element_type].array_from_vector_container(
-        points)
+    
+    point_values = itk.array_from_vector_container(points)
 
     assert(geometry['vtkClass'] == 'vtkPolyData')
     assert(geometry['points']['vtkClass'] == 'vtkPoints')


### PR DESCRIPTION
- Update package requirements for ITK v5.2 release
- Update for PyVectorContainer template changes introduced in ITK 5.2 (this affects geometry rendering)
- Drop CI checks for Python 3.5 which is no longer maintained

Resolves package dependency issues noted in #406. 