### PR TITLE
ENH: Bump to dev 0.33.1 and update ITK package dependencies

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -10,12 +10,12 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/itkwidgets/_version.py
+++ b/itkwidgets/_version.py
@@ -1,4 +1,4 @@
-version_info = (0, 33, 0, 'dev', 0)
+version_info = (0, 33, 1, 'dev', 0)
 
 _specifier_ = {
     'dev': 'dev',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 colorcet
-itk-core>=5.2.0.post2
-itk-filtering>=5.2.0.post2
-itk-meshtopolydata>=0.7.1
+itk-core>=5.3rc04
+itk-filtering>=5.3rc04
+itk-meshtopolydata>=0.8.2
 ipydatawidgets>=4.0.1
 ipywidgets>=7.5.1
 ipympl>=0.4.1


### PR DESCRIPTION
Bumps `itk` and `itk-meshtopolydata` Python dependencies to address
meshtopolydata crash in older package versions. Closes #448.