### PR TITLE
BUG: Fix display in Jupyter Notebook

### DIFF
--- a/itkwidgets/viewer.py
+++ b/itkwidgets/viewer.py
@@ -30,6 +30,9 @@ class ViewerRPC:
         return data, option
 
     async def setup(self):
+        pass
+
+    async def run(self, ctx):
         """ImJoy plugin setup function."""
         global _viewer_count
         itk_viewer = await api.createWindow(


### PR DESCRIPTION
Moving the viewer initialization into the `run` function prevents the viewer from being displayed as a dialog in the Jupyter Notebook and instead displays it inline as expected. This also prevents the multiple window creation that was happening in Colab. From the [ImJoy docs](https://imjoy.io/docs/#/development?id=ltscriptgt-block):
- **setup()** function: executed when a plugin is loaded and it initializes for the first time.
- **run()** function: will be called each time a plugin is executed. When executed, an object (for JavaScript) or a dictionary (for Python) with context (named ctx) will be passed into the function. The returned result will be displayed as a new window or passed to the next op in a workflow.

I am not entirely sure why this change would affect the way that the output is displayed but this change better matches the examples that ImJoy provides ([computation plugin](https://imjoy.io/docs/#/i2k_tutorial?id=_4-build-computation-plugin-in-python), [itk-vtk-viewer](https://imjoy.io/docs/#/i2k_tutorial?id=display-an-image-with-itkvtk-viewer-vizarr-and-kaibu), [image viewer](https://imjoy.io/docs/#/i2k_tutorial?id=connect-your-image-viewer-to-the-python-plugin))