### PR TITLE
DOC: Add instructions for jupter lab extension installation

### DIFF
--- a/docs/quick_start_guide.md
+++ b/docs/quick_start_guide.md
@@ -20,6 +20,7 @@ For Jupyter Lab 3 run:
 
 ```bash
 pip install 'itkwidgets>=1.0a5' imjoy-jupyterlab-extension
+jupyter labextension install imjoy-jupyter-extension
 ```
 
 Then look for the ImJoy icon at the top in the Jupyter Notebook:


### PR DESCRIPTION
In trying a fresh environment it seems that the `jupyter` command is required in order to install the ImJoy extension for JupyterLab.