### PR TITLE
Notebook updates

### DIFF
--- a/examples/Hello3DWorld.ipynb
+++ b/examples/Hello3DWorld.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "import sys\n",
     "\n",
-    "!{sys.executable} -m pip install --pre itkwidgets imageio"
+    "!{sys.executable} -m pip install -q \"itkwidgets>=1.0a5\" imageio"
    ]
   },
   {

--- a/examples/NumPyArrayPointSet.ipynb
+++ b/examples/NumPyArrayPointSet.ipynb
@@ -8,7 +8,8 @@
    "outputs": [],
    "source": [
     "import sys\n",
-    "!{sys.executable} -m pip install -q --pre itkwidgets"
+    "\n",
+    "!{sys.executable} -m pip install -q \"itkwidgets>=1.0a5\""
    ]
   },
   {

--- a/examples/integrations/MONAI/transform_visualization.ipynb
+++ b/examples/integrations/MONAI/transform_visualization.ipynb
@@ -10,7 +10,7 @@
     "# Install dependencies for this example\n",
     "import sys\n",
     "\n",
-    "!{sys.executable} -m pip install -q \"monai-weekly[nibabel, matplotlib]\" itkwidgets"
+    "!{sys.executable} -m pip install -q \"monai-weekly[nibabel, matplotlib]\" \"itkwidgets>=1.0a5\""
    ]
   },
   {
@@ -52,13 +52,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c5e68150-c129-45d9-93bf-cf955451da3a",
+   "execution_count": 3,
+   "id": "205efb9f-f41b-4df2-8c48-5636b637856b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/tmp/tmp8obmuhkg\n"
+     ]
+    }
+   ],
    "source": [
     "directory = os.environ.get(\"MONAI_DATA_DIRECTORY\")\n",
-    "root_dir = '/home/local/KHQ/brianna.major/tensorboard_logs/newest_logs/spleen'\n",
+    "root_dir = tempfile.mkdtemp() if directory is None else directory\n",
     "print(root_dir)"
    ]
   },
@@ -150,9 +158,7 @@
    "id": "98caa02e-a37a-46a1-a33e-86e65452a186",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "isinstance(data[\"image\"][0, 0, :, :, :] * 255, torch.Tensor)"
-   ]
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/integrations/PyImageJ/ImageJImgLib2.ipynb
+++ b/examples/integrations/PyImageJ/ImageJImgLib2.ipynb
@@ -84,31 +84,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "08da7bd9-3160-47a1-8e54-a8e77bbb2ff1",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(type(image))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "48b151f6-cfc4-4522-aa02-04c8301d3667",
    "metadata": {},
    "outputs": [],
    "source": [
+    "print(type(image))\n",
+    "\n",
     "image_arr = itk.array_view_from_image(image)\n",
-    "print(type(image_arr))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0560854d-735f-436f-a52d-2fe133350c84",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "print(type(image_arr))\n",
+    "\n",
     "image_java = ij.py.to_java(image_arr)\n",
     "print(type(image_java))"
    ]

--- a/examples/integrations/PyVista/LiDAR.ipynb
+++ b/examples/integrations/PyVista/LiDAR.ipynb
@@ -9,7 +9,8 @@
    "source": [
     "# Install dependencies for this example\n",
     "import sys\n",
-    "!{sys.executable} -m pip install -q pyvista"
+    "\n",
+    "!{sys.executable} -m pip install -q pyvista \"itkwidgets>=1.0a5\""
    ]
   },
   {

--- a/examples/integrations/PyVista/UniformGrid.ipynb
+++ b/examples/integrations/PyVista/UniformGrid.ipynb
@@ -9,7 +9,8 @@
    "source": [
     "# Install dependencies for this example\n",
     "import sys\n",
-    "!{sys.executable} -m pip install -q pyvista --pre itkwidgets"
+    "\n",
+    "!{sys.executable} -m pip install -q pyvista \"itkwidgets>=1.0a5\""
    ]
   },
   {
@@ -43,7 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer = view(image_from_array)"
+    "view(dataset)"
    ]
   },
   {

--- a/examples/integrations/dask/DaskArray.ipynb
+++ b/examples/integrations/dask/DaskArray.ipynb
@@ -5,91 +5,13 @@
    "execution_count": 1,
    "id": "9572df40-3091-473c-ae4e-d7267c7b1205",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: dask in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (2022.6.1)\n",
-      "Requirement already satisfied: toolz in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (0.11.2)\n",
-      "Requirement already satisfied: scikit-image in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (0.19.3)\n",
-      "Requirement already satisfied: matplotlib in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (3.5.2)\n",
-      "Requirement already satisfied: itk-io in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (5.3rc4)\n",
-      "Requirement already satisfied: itkwidgets in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (1.0a4)\n",
-      "Requirement already satisfied: partd>=0.3.10 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from dask) (1.2.0)\n",
-      "Requirement already satisfied: pyyaml>=5.3.1 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from dask) (6.0)\n",
-      "Requirement already satisfied: packaging>=20.0 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from dask) (21.3)\n",
-      "Requirement already satisfied: fsspec>=0.6.0 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from dask) (2022.5.0)\n",
-      "Requirement already satisfied: cloudpickle>=1.1.1 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from dask) (2.1.0)\n",
-      "Requirement already satisfied: numpy>=1.17.0 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from scikit-image) (1.23.0rc3)\n",
-      "Requirement already satisfied: PyWavelets>=1.1.1 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from scikit-image) (1.3.0)\n",
-      "Requirement already satisfied: tifffile>=2019.7.26 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from scikit-image) (2022.5.4)\n",
-      "Requirement already satisfied: scipy>=1.4.1 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from scikit-image) (1.8.1)\n",
-      "Requirement already satisfied: pillow!=7.1.0,!=7.1.1,!=8.3.0,>=6.1.0 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from scikit-image) (9.1.1)\n",
-      "Requirement already satisfied: imageio>=2.4.1 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from scikit-image) (2.19.3)\n",
-      "Requirement already satisfied: networkx>=2.2 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from scikit-image) (2.8.4)\n",
-      "Requirement already satisfied: kiwisolver>=1.0.1 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from matplotlib) (1.4.3)\n",
-      "Requirement already satisfied: fonttools>=4.22.0 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from matplotlib) (4.33.3)\n",
-      "Requirement already satisfied: cycler>=0.10 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from matplotlib) (0.11.0)\n",
-      "Requirement already satisfied: python-dateutil>=2.7 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from matplotlib) (2.8.2)\n",
-      "Requirement already satisfied: pyparsing>=2.2.1 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from matplotlib) (3.0.9)\n",
-      "Requirement already satisfied: itk-core==5.3rc4 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from itk-io) (5.3rc4)\n",
-      "Requirement already satisfied: imjoy in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from itkwidgets) (0.11.20)\n",
-      "Requirement already satisfied: imjoy-utils>=0.1.2 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from itkwidgets) (0.1.2)\n",
-      "Requirement already satisfied: zarr in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from itkwidgets) (2.12.0a2)\n",
-      "Requirement already satisfied: numcodecs in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from itkwidgets) (0.10.0a3)\n",
-      "Requirement already satisfied: imjoy-rpc>=0.5.13 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from itkwidgets) (0.5.13)\n",
-      "Requirement already satisfied: itkwasm in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from itkwidgets) (1.0b0)\n",
-      "Requirement already satisfied: websockets in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from imjoy-rpc>=0.5.13->itkwidgets) (10.3)\n",
-      "Requirement already satisfied: msgpack>=1.0.2 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from imjoy-rpc>=0.5.13->itkwidgets) (1.0.4)\n",
-      "Requirement already satisfied: shortuuid>=1.0.8 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from imjoy-rpc>=0.5.13->itkwidgets) (1.0.9)\n",
-      "Requirement already satisfied: locket in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from partd>=0.3.10->dask) (1.0.0)\n",
-      "Requirement already satisfied: six>=1.5 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from python-dateutil>=2.7->matplotlib) (1.16.0)\n",
-      "Requirement already satisfied: jinja2>=3 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from imjoy->itkwidgets) (3.1.2)\n",
-      "Requirement already satisfied: python-dotenv>=0.17.0 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from imjoy->itkwidgets) (0.20.0)\n",
-      "Requirement already satisfied: uvicorn>=0.13.4 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from imjoy->itkwidgets) (0.17.6)\n",
-      "Requirement already satisfied: aiobotocore>=1.4.2 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from imjoy->itkwidgets) (2.3.3)\n",
-      "Requirement already satisfied: typing-extensions>=3.7.4.3 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from imjoy->itkwidgets) (4.2.0)\n",
-      "Requirement already satisfied: fastapi>=0.70.0 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from imjoy->itkwidgets) (0.78.0)\n",
-      "Requirement already satisfied: python-jose==3.3.0 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from imjoy->itkwidgets) (3.3.0)\n",
-      "Requirement already satisfied: python-engineio==4.0.0 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from imjoy->itkwidgets) (4.0.0)\n",
-      "Requirement already satisfied: pydantic[email]>=1.8.2 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from imjoy->itkwidgets) (1.9.1)\n",
-      "Requirement already satisfied: aiofiles in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from imjoy->itkwidgets) (0.8.0)\n",
-      "Requirement already satisfied: python-socketio[asyncio_client]==5.0.4 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from imjoy->itkwidgets) (5.0.4)\n",
-      "Requirement already satisfied: rsa in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from python-jose==3.3.0->imjoy->itkwidgets) (4.8)\n",
-      "Requirement already satisfied: ecdsa!=0.15 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from python-jose==3.3.0->imjoy->itkwidgets) (0.18.0b2)\n",
-      "Requirement already satisfied: pyasn1 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from python-jose==3.3.0->imjoy->itkwidgets) (0.4.8)\n",
-      "Requirement already satisfied: bidict>=0.21.0 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from python-socketio[asyncio_client]==5.0.4->imjoy->itkwidgets) (0.22.0)\n",
-      "Requirement already satisfied: aiohttp>=3.4 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from python-socketio[asyncio_client]==5.0.4->imjoy->itkwidgets) (4.0.0a1)\n",
-      "Requirement already satisfied: asciitree in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from zarr->itkwidgets) (0.3.3)\n",
-      "Requirement already satisfied: fasteners in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from zarr->itkwidgets) (0.17.3)\n",
-      "Requirement already satisfied: aioitertools>=0.5.1 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from aiobotocore>=1.4.2->imjoy->itkwidgets) (0.10.0)\n",
-      "Requirement already satisfied: botocore<1.24.22,>=1.24.21 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from aiobotocore>=1.4.2->imjoy->itkwidgets) (1.24.21)\n",
-      "Requirement already satisfied: wrapt>=1.10.10 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from aiobotocore>=1.4.2->imjoy->itkwidgets) (1.14.1)\n",
-      "Requirement already satisfied: starlette==0.19.1 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from fastapi>=0.70.0->imjoy->itkwidgets) (0.19.1)\n",
-      "Requirement already satisfied: anyio<5,>=3.4.0 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from starlette==0.19.1->fastapi>=0.70.0->imjoy->itkwidgets) (3.6.1)\n",
-      "Requirement already satisfied: MarkupSafe>=2.0 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from jinja2>=3->imjoy->itkwidgets) (2.1.1)\n",
-      "Requirement already satisfied: email-validator>=1.0.3 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from pydantic[email]>=1.8.2->imjoy->itkwidgets) (1.2.1)\n",
-      "Requirement already satisfied: h11>=0.8 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from uvicorn>=0.13.4->imjoy->itkwidgets) (0.13.0)\n",
-      "Requirement already satisfied: asgiref>=3.4.0 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from uvicorn>=0.13.4->imjoy->itkwidgets) (3.5.2)\n",
-      "Requirement already satisfied: click>=7.0 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from uvicorn>=0.13.4->imjoy->itkwidgets) (8.1.3)\n",
-      "Requirement already satisfied: async-timeout<4.0,>=3.0 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from aiohttp>=3.4->python-socketio[asyncio_client]==5.0.4->imjoy->itkwidgets) (3.0.1)\n",
-      "Requirement already satisfied: yarl<2.0,>=1.0 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from aiohttp>=3.4->python-socketio[asyncio_client]==5.0.4->imjoy->itkwidgets) (1.7.2)\n",
-      "Requirement already satisfied: multidict<5.0,>=4.5 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from aiohttp>=3.4->python-socketio[asyncio_client]==5.0.4->imjoy->itkwidgets) (4.7.6)\n",
-      "Requirement already satisfied: chardet<4.0,>=2.0 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from aiohttp>=3.4->python-socketio[asyncio_client]==5.0.4->imjoy->itkwidgets) (3.0.4)\n",
-      "Requirement already satisfied: attrs>=17.3.0 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from aiohttp>=3.4->python-socketio[asyncio_client]==5.0.4->imjoy->itkwidgets) (21.4.0)\n",
-      "Requirement already satisfied: urllib3<1.27,>=1.25.4 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from botocore<1.24.22,>=1.24.21->aiobotocore>=1.4.2->imjoy->itkwidgets) (1.26.9)\n",
-      "Requirement already satisfied: jmespath<2.0.0,>=0.7.1 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from botocore<1.24.22,>=1.24.21->aiobotocore>=1.4.2->imjoy->itkwidgets) (1.0.1)\n",
-      "Requirement already satisfied: idna>=2.0.0 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from email-validator>=1.0.3->pydantic[email]>=1.8.2->imjoy->itkwidgets) (3.3)\n",
-      "Requirement already satisfied: dnspython>=1.15.0 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from email-validator>=1.0.3->pydantic[email]>=1.8.2->imjoy->itkwidgets) (2.2.1)\n",
-      "Requirement already satisfied: sniffio>=1.1 in /home/local/KHQ/brianna.major/.virtualenvs/itkwidgets/lib/python3.8/site-packages (from anyio<5,>=3.4.0->starlette==0.19.1->fastapi>=0.70.0->imjoy->itkwidgets) (1.2.0)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Install dependencies for this example\n",
     "import sys\n",
-    "!{sys.executable} -m pip install dask toolz scikit-image matplotlib itk-io itkwidgets"
+    "\n",
+    "!{sys.executable} -m pip install -q --upgrade --pre itk-io\n",
+    "!{sys.executable} -m pip install -q dask toolz scikit-image matplotlib \"itkwidgets>=1.0a5\""
    ]
   },
   {
@@ -186,137 +108,7 @@
    "execution_count": 5,
    "id": "d1792a9c-5120-4627-b7cb-ddf98f0451dd",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "    <tr>\n",
-       "        <td>\n",
-       "            <table>\n",
-       "                <thead>\n",
-       "                    <tr>\n",
-       "                        <td> </td>\n",
-       "                        <th> Array </th>\n",
-       "                        <th> Chunk </th>\n",
-       "                    </tr>\n",
-       "                </thead>\n",
-       "                <tbody>\n",
-       "                    \n",
-       "                    <tr>\n",
-       "                        <th> Bytes </th>\n",
-       "                        <td> 7.63 MiB </td>\n",
-       "                        <td> 39.06 kiB </td>\n",
-       "                    </tr>\n",
-       "                    \n",
-       "                    <tr>\n",
-       "                        <th> Shape </th>\n",
-       "                        <td> (200, 200, 200) </td>\n",
-       "                        <td> (1, 200, 200) </td>\n",
-       "                    </tr>\n",
-       "                    <tr>\n",
-       "                        <th> Count </th>\n",
-       "                        <td> 200 Tasks </td>\n",
-       "                        <td> 200 Chunks </td>\n",
-       "                    </tr>\n",
-       "                    <tr>\n",
-       "                    <th> Type </th>\n",
-       "                    <td> uint8 </td>\n",
-       "                    <td> numpy.ndarray </td>\n",
-       "                    </tr>\n",
-       "                </tbody>\n",
-       "            </table>\n",
-       "        </td>\n",
-       "        <td>\n",
-       "        <svg width=\"250\" height=\"240\" style=\"stroke:rgb(0,0,0);stroke-width:1\" >\n",
-       "\n",
-       "  <!-- Horizontal lines -->\n",
-       "  <line x1=\"10\" y1=\"0\" x2=\"80\" y2=\"70\" style=\"stroke-width:2\" />\n",
-       "  <line x1=\"10\" y1=\"120\" x2=\"80\" y2=\"190\" style=\"stroke-width:2\" />\n",
-       "\n",
-       "  <!-- Vertical lines -->\n",
-       "  <line x1=\"10\" y1=\"0\" x2=\"10\" y2=\"120\" style=\"stroke-width:2\" />\n",
-       "  <line x1=\"13\" y1=\"3\" x2=\"13\" y2=\"123\" />\n",
-       "  <line x1=\"17\" y1=\"7\" x2=\"17\" y2=\"127\" />\n",
-       "  <line x1=\"20\" y1=\"10\" x2=\"20\" y2=\"130\" />\n",
-       "  <line x1=\"24\" y1=\"14\" x2=\"24\" y2=\"134\" />\n",
-       "  <line x1=\"28\" y1=\"18\" x2=\"28\" y2=\"138\" />\n",
-       "  <line x1=\"32\" y1=\"22\" x2=\"32\" y2=\"142\" />\n",
-       "  <line x1=\"35\" y1=\"25\" x2=\"35\" y2=\"145\" />\n",
-       "  <line x1=\"39\" y1=\"29\" x2=\"39\" y2=\"149\" />\n",
-       "  <line x1=\"43\" y1=\"33\" x2=\"43\" y2=\"153\" />\n",
-       "  <line x1=\"47\" y1=\"37\" x2=\"47\" y2=\"157\" />\n",
-       "  <line x1=\"50\" y1=\"40\" x2=\"50\" y2=\"160\" />\n",
-       "  <line x1=\"54\" y1=\"44\" x2=\"54\" y2=\"164\" />\n",
-       "  <line x1=\"58\" y1=\"48\" x2=\"58\" y2=\"168\" />\n",
-       "  <line x1=\"61\" y1=\"51\" x2=\"61\" y2=\"171\" />\n",
-       "  <line x1=\"65\" y1=\"55\" x2=\"65\" y2=\"175\" />\n",
-       "  <line x1=\"69\" y1=\"59\" x2=\"69\" y2=\"179\" />\n",
-       "  <line x1=\"72\" y1=\"62\" x2=\"72\" y2=\"182\" />\n",
-       "  <line x1=\"76\" y1=\"66\" x2=\"76\" y2=\"186\" />\n",
-       "  <line x1=\"80\" y1=\"70\" x2=\"80\" y2=\"190\" style=\"stroke-width:2\" />\n",
-       "\n",
-       "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"10.0,0.0 80.58823529411765,70.58823529411765 80.58823529411765,190.58823529411765 10.0,120.0\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
-       "\n",
-       "  <!-- Horizontal lines -->\n",
-       "  <line x1=\"10\" y1=\"0\" x2=\"130\" y2=\"0\" style=\"stroke-width:2\" />\n",
-       "  <line x1=\"13\" y1=\"3\" x2=\"133\" y2=\"3\" />\n",
-       "  <line x1=\"17\" y1=\"7\" x2=\"137\" y2=\"7\" />\n",
-       "  <line x1=\"20\" y1=\"10\" x2=\"140\" y2=\"10\" />\n",
-       "  <line x1=\"24\" y1=\"14\" x2=\"144\" y2=\"14\" />\n",
-       "  <line x1=\"28\" y1=\"18\" x2=\"148\" y2=\"18\" />\n",
-       "  <line x1=\"32\" y1=\"22\" x2=\"152\" y2=\"22\" />\n",
-       "  <line x1=\"35\" y1=\"25\" x2=\"155\" y2=\"25\" />\n",
-       "  <line x1=\"39\" y1=\"29\" x2=\"159\" y2=\"29\" />\n",
-       "  <line x1=\"43\" y1=\"33\" x2=\"163\" y2=\"33\" />\n",
-       "  <line x1=\"47\" y1=\"37\" x2=\"167\" y2=\"37\" />\n",
-       "  <line x1=\"50\" y1=\"40\" x2=\"170\" y2=\"40\" />\n",
-       "  <line x1=\"54\" y1=\"44\" x2=\"174\" y2=\"44\" />\n",
-       "  <line x1=\"58\" y1=\"48\" x2=\"178\" y2=\"48\" />\n",
-       "  <line x1=\"61\" y1=\"51\" x2=\"181\" y2=\"51\" />\n",
-       "  <line x1=\"65\" y1=\"55\" x2=\"185\" y2=\"55\" />\n",
-       "  <line x1=\"69\" y1=\"59\" x2=\"189\" y2=\"59\" />\n",
-       "  <line x1=\"72\" y1=\"62\" x2=\"192\" y2=\"62\" />\n",
-       "  <line x1=\"76\" y1=\"66\" x2=\"196\" y2=\"66\" />\n",
-       "  <line x1=\"80\" y1=\"70\" x2=\"200\" y2=\"70\" style=\"stroke-width:2\" />\n",
-       "\n",
-       "  <!-- Vertical lines -->\n",
-       "  <line x1=\"10\" y1=\"0\" x2=\"80\" y2=\"70\" style=\"stroke-width:2\" />\n",
-       "  <line x1=\"130\" y1=\"0\" x2=\"200\" y2=\"70\" style=\"stroke-width:2\" />\n",
-       "\n",
-       "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"10.0,0.0 130.0,0.0 200.58823529411765,70.58823529411765 80.58823529411765,70.58823529411765\" style=\"fill:#8B4903A0;stroke-width:0\"/>\n",
-       "\n",
-       "  <!-- Horizontal lines -->\n",
-       "  <line x1=\"80\" y1=\"70\" x2=\"200\" y2=\"70\" style=\"stroke-width:2\" />\n",
-       "  <line x1=\"80\" y1=\"190\" x2=\"200\" y2=\"190\" style=\"stroke-width:2\" />\n",
-       "\n",
-       "  <!-- Vertical lines -->\n",
-       "  <line x1=\"80\" y1=\"70\" x2=\"80\" y2=\"190\" style=\"stroke-width:2\" />\n",
-       "  <line x1=\"200\" y1=\"70\" x2=\"200\" y2=\"190\" style=\"stroke-width:2\" />\n",
-       "\n",
-       "  <!-- Colored Rectangle -->\n",
-       "  <polygon points=\"80.58823529411765,70.58823529411765 200.58823529411765,70.58823529411765 200.58823529411765,190.58823529411765 80.58823529411765,190.58823529411765\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
-       "\n",
-       "  <!-- Text -->\n",
-       "  <text x=\"140.588235\" y=\"210.588235\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >200</text>\n",
-       "  <text x=\"220.588235\" y=\"130.588235\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,220.588235,130.588235)\">200</text>\n",
-       "  <text x=\"35.294118\" y=\"175.294118\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,35.294118,175.294118)\">200</text>\n",
-       "</svg>\n",
-       "        </td>\n",
-       "    </tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "dask.array<imread, shape=(200, 200, 200), dtype=uint8, chunksize=(1, 200, 200), chunktype=numpy.ndarray>"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "stack = dask.array.image.imread('emdata_janelia_822252/*')\n",
     "stack"
@@ -324,68 +116,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "b37a638b-3c96-41fc-bc75-67ce22cfdcf4",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "window.connectPlugin && window.connectPlugin(\"31434865-eb7f-4310-815c-bedeaaa84e9d\")"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div id=\"d70435a6-13f4-49a6-98a8-f2893bbdd48a\"></div>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<itkwidgets.viewer.Viewer at 0x7f475dfae2b0>"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "view(stack, shadow=False, gradient_opacity=0.4, ui_collapsed=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "dd58b856-270f-4c45-b3ca-b000c2842b30",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'imread-70e791288923d1af6359131d9aee9ffc'"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "stack.name"
    ]
   },
   {

--- a/examples/integrations/itk/3DImage.ipynb
+++ b/examples/integrations/itk/3DImage.ipynb
@@ -7,9 +7,9 @@
    "outputs": [],
    "source": [
     "# Install dependencies for this example\n",
-    "# Note: This does not include itkwidgets, itself\n",
     "import sys\n",
-    "!{sys.executable} -m pip install --upgrade --pre itk-io"
+    "\n",
+    "!{sys.executable} -m pip install -q --upgrade --pre itk-io \"itkwidgets>=1.0a5\""
    ]
   },
   {
@@ -41,44 +41,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "window.connectPlugin && window.connectPlugin(\"0ffcf0d9-b868-44f6-b374-72bc714717e7\")"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div id=\"074b5aed-86a7-4ae0-aa36-0f77e4d47ec3\"></div>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<itkwidgets.viewer.Viewer at 0x7fe59b004250>"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "image = itk.imread(file_name)\n",
     "view(image, rotate=True, gradient_opacity=0.4)"

--- a/examples/integrations/vtk/vtkImageData.ipynb
+++ b/examples/integrations/vtk/vtkImageData.ipynb
@@ -10,7 +10,7 @@
     "# Install dependencies for this example\n",
     "import sys\n",
     "\n",
-    "!{sys.executable} -m pip install --pre itkwidgets vtk"
+    "!{sys.executable} -m pip install -q \"itkwidgets>=1.0a5\" vtk"
    ]
   },
   {
@@ -62,19 +62,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer = view(vtk_image)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "12679972-1886-4e58-b9cc-f2f35050a6b2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from vtk.util.numpy_support import vtk_to_numpy\n",
-    "array = vtk_to_numpy(vtk_image.GetPointData().GetScalars())\n",
-    "array.shape"
+    "view(vtk_image)"
    ]
   },
   {

--- a/examples/integrations/vtk/vtkPolyDataPointSet.ipynb
+++ b/examples/integrations/vtk/vtkPolyDataPointSet.ipynb
@@ -10,7 +10,7 @@
     "# Install dependencies for this example\n",
     "import sys\n",
     "\n",
-    "!{sys.executable} -m pip install --pre itkwidgets vtk"
+    "!{sys.executable} -m pip install -q \"itkwidgets>=1.0a5\" vtk"
    ]
   },
   {
@@ -62,7 +62,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer = view(point_sets=vtk_poly)"
+    "view(point_sets=vtk_poly)"
    ]
   },
   {

--- a/examples/integrations/xarray/DataArray.ipynb
+++ b/examples/integrations/xarray/DataArray.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "import sys\n",
     "\n",
-    "!{sys.executable} -m pip install -q --pre itkwidgets netCDF4"
+    "!{sys.executable} -m pip install -q \"itkwidgets>=1.0a5\" netCDF4 xarray"
    ]
   },
   {
@@ -32,7 +32,7 @@
    "outputs": [],
    "source": [
     "# load in the file\n",
-    "ds = xr.tutorial.open_dataset(\"ROMS_example.nc\", chunks={\"ocean_time\": 1})\n",
+    "ds = xr.tutorial.open_dataset(\"ROMS_example\")\n",
     "\n",
     "# This is a way to turn on chunking and lazy evaluation. Opening with mfdataset, or\n",
     "# setting the chunking in the open_dataset would also achieve this.\n",

--- a/examples/integrations/zarr/OME-NGFF-Brainstem-MRI.ipynb
+++ b/examples/integrations/zarr/OME-NGFF-Brainstem-MRI.ipynb
@@ -3,6 +3,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7098496c-ed91-42c9-886e-d4f4f7a9e7cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install dependencies for this example\n",
+    "import sys\n",
+    "\n",
+    "!{sys.executable} -m pip install -q \"itkwidgets>=1.0a5\" zarr fsspec['http']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "2933a72d-ee4d-475c-9573-990d435c5788",
    "metadata": {},
    "outputs": [],
@@ -51,6 +64,17 @@
    "source": [
     "view(brainstem)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5591555a-0dfd-4058-8e75-2c03d9d262b4",
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/itkwidgets/_type_aliases.py
+++ b/itkwidgets/_type_aliases.py
@@ -19,7 +19,6 @@ Point_Sets = Union[np.ndarray, itkwasm.PointSet, zarr.Group]
 if HAVE_ITK:
     import itk
     Image = Union[Image, itk.Image]
-    Point_Sets = Union[Point_Sets, itk.GroupSpatialObject]
 if HAVE_VTK:
     import vtk
     Image = Union[Image, vtk.vtkImageData]

--- a/itkwidgets/integrations/__init__.py
+++ b/itkwidgets/integrations/__init__.py
@@ -87,11 +87,6 @@ async def _set_viewer_point_sets(itk_viewer, point_sets):
         await itk_viewer.setPointSets(point_sets)
     elif isinstance(point_sets, zarr.Group):
         await itk_viewer.setPointSets(point_sets)
-    elif HAVE_ITK:
-        import itk
-        if isinstance(point_sets, itk.GroupSpatialObject):
-            wasm_point_sets = itk_group_spatial_object_to_wasm_point_set(point_sets)
-            await itk_viewer.setPointSets(wasm_point_sets)
     if HAVE_VTK:
         import vtk
         if isinstance(point_sets, vtk.vtkPolyData):
@@ -135,8 +130,6 @@ def _detect_render_type(data, input_type) -> RenderType:
         import itk
         if isinstance(data, itk.Image):
             return RenderType.IMAGE
-        elif isinstance(data, itk.GroupSpatialObject):
-            return RenderType.POINT_SET
     if HAVE_VTK:
         import vtk
         if isinstance(data, vtk.vtkImageData):


### PR DESCRIPTION
Some notebooks made assumptions about environment or had old debug information. This PR removes debug cells and ensures we always install the correct version of `itkwidgets`. This also removes references to `itk.GroupSpatialObject`. This is not raising errors in testing in Jupyter Notebook or JupyterLab, however for some reason this errors out in Colab an prevents itkwidgets from being used.