### PR TITLE
ENH: Include imjoy-elfinder in options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,9 +51,11 @@ Source = "https://github.com/InsightSoftwareConsortium/itkwidgets"
 [project.optional-dependencies]
 lab = [
     "imjoy-jupyter-extension >=0.3.0",
+    "imjoy-elfinder[jupyter]"
 ]
 notebook = [
     "imjoy-jupyterlab-extension >=0.1.13",
+    "imjoy-elfinder[jupyter]"
 ]
 test = [
     "pytest >=2.7.3",


### PR DESCRIPTION
Addresses part of #479 by adding `imjoy-elfinder` dependency to options