### PR TITLE
Label fixes

### DIFF
--- a/examples/integrations/MONAI/transform_visualization.ipynb
+++ b/examples/integrations/MONAI/transform_visualization.ipynb
@@ -149,7 +149,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "view(image=data[\"image\"][0, 0, :, :, :] * 255, gradient_opacity=0.4)"
+    "view(image=data[\"image\"][0, 0, :, :, :] * 255, label_image=data[\"label\"][0, 0, :, :, :] * 255, gradient_opacity=0.4)"
    ]
   },
   {

--- a/itkwidgets/viewer.py
+++ b/itkwidgets/viewer.py
@@ -70,7 +70,7 @@ class ViewerRPC:
                 result = await _get_viewer_image(data)
             elif render_type is RenderType.POINT_SET:
                 result = await _get_viewer_point_sets(data)
-            if not result:
+            if result is None:
                 result = data
             self.init_data[key] = result
 

--- a/itkwidgets/viewer.py
+++ b/itkwidgets/viewer.py
@@ -26,7 +26,7 @@ class ViewerRPC:
         self.init_data = {}
 
     def _get_input_data(self):
-        input_options = ["data", "image", "point_sets"]
+        input_options = ["data", "image", "label_image", "point_sets"]
         inputs = []
         for option in input_options:
             data = self._init_viewer_kwargs.get(option, None)

--- a/itkwidgets/viewer.py
+++ b/itkwidgets/viewer.py
@@ -248,6 +248,9 @@ def view(data=None, **kwargs):
     ^^^^^^
     image : array_like, itk.Image, or vtk.vtkImageData
         The 2D or 3D image to visualize.
+    label_image: array_like, itk.Image, or vtk.vtkImageData
+        The 2D or 3D label map to visualize. If an image is also provided, the
+        label map must have the same size.
     label_blend: float, default: 0.5
         Label map blend with intensity image, from 0.0 to 1.0.
     label_names: list of (label_value, label_name)


### PR DESCRIPTION
- Fixes another bug that was introduced by the incorrectly resolved merge conflicts. Support for the `label_image` input was lost, added back in now.
- Adds the `label_image` info to the doc string
- Updates the MONAI example notebook to use `label_image`

Relies on the changes in Kitware/itk-vtk-viewer#538