### PR TITLE
BUG: Fix uninitialized variable in viewer

### DIFF
--- a/js/lib/viewer.js
+++ b/js/lib/viewer.js
@@ -232,7 +232,7 @@ const createRenderingPipeline = (
     backgroundColor[2] = rgb[2] / 255.0
   }
   const backgroundTrait = domWidgetView.model.get('background')
-  if (backgroundTrait.length !== 0) {
+  if (backgroundTrait && !!backgroundTrait.length) {
     backgroundColor = backgroundTrait
   }
   const viewerStyle = {
@@ -721,7 +721,7 @@ const ViewerView = widgets.DOMWidgetView.extend({
     }
     this.model.itkVtkViewer.on('backgroundColorChanged', onBackgroundChanged)
     const background = this.model.get('background')
-    if (background.length === 0) {
+    if (background === null|| background.length === 0) {
       this.model.set('background', this.model.itkVtkViewer.getBackgroundColor())
     }
 
@@ -930,7 +930,7 @@ const ViewerView = widgets.DOMWidgetView.extend({
       onChannelsChanged
     )
     const channels = this.model.get('channels')
-    if (channels.length === 0) {
+    if (channels === null || channels.length === 0) {
       this.model.set('channels', this.model.itkVtkViewer.getComponentVisibilities())
     }
 


### PR DESCRIPTION
## Error

Browser developer console:
```
Uncaught (in promise) TypeError: channels is null
    initialize_itkVtkViewer viewer.js:933
    initialize_viewer viewer.js:1852
    createRenderingPipeline viewer.js:286
    render viewer.js:1285
viewer.js:933:8
```

Problems:
- See #398, #429 
- `point_set_colors` does not work
- ...

## Steps to reproduce

1. Open e.g. `examples/NumPyArrayPointSet.ipynb`
2. Open developer console of the browser
3. Run the notebook
4. Look in the console
   1. Error message in console
   2. All point clouds are white (normally they have different colors)


## Fix

This just adds a null check to the `channels` attribute.
Additionally, a similar case is also mitigated (`background`).


Fixes #398
Fixes #429
