### PR TITLE
DOCS: Infer version from git tags

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from sphinx.application import Sphinx
 import subprocess
 import os
-import json
+import re
 
 # -- Project information -----------------------------------------------------
 
@@ -25,8 +25,10 @@ project = 'itkwidgets'
 copyright = '2022, Matthew McCormick'
 author = 'Matthew McCormick'
 
-# The full version, including alpha/beta/rc tags
-release = '1.0a7'
+# The full version, including alpha/beta/rc tags.
+release = re.sub('^v', '', os.popen('git describe').read().strip())
+# The short X.Y version.
+version = release
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
Following the suggestion [here](https://protips.readthedocs.io/git-tag-version.html) this uses `git describe` to generate a version number based on current Git commit. `git describe` returns the tag name we are on (ex: `v1.0a7`).

Fixes #495 