### PR TITLE
BUG: ImJoy extension options were flipped

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,11 +52,11 @@ Source = "https://github.com/InsightSoftwareConsortium/itkwidgets"
 
 [project.optional-dependencies]
 lab = [
-    "imjoy-jupyter-extension >=0.3.0",
+    "imjoy-jupyterlab-extension >=0.1.13",
     "imjoy-elfinder[jupyter]"
 ]
 notebook = [
-    "imjoy-jupyterlab-extension >=0.1.13",
+    "imjoy-jupyter-extension >=0.3.0",
     "imjoy-elfinder[jupyter]"
 ]
 test = [


### PR DESCRIPTION
Flip
```
lab = [ "imjoy-jupyter-extension >=0.3.0", "imjoy-elfinder[jupyter]" ]
notebook = [ "imjoy-jupyterlab-extension >=0.1.13", "imjoy-elfinder[jupyter]" ]
```
to be
```
lab = [ "imjoy-jupyterlab-extension >=0.1.13", "imjoy-elfinder[jupyter]" ]
notebook = [ "imjoy-jupyter-extension >=0.3.0", "imjoy-elfinder[jupyter]" ]
```