### PR TITLE
BUG: Remove release notes from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,12 +15,8 @@ jobs:
       run: python -m pip install --upgrade hatch
     - name: Build
       run: hatch build
-    - name: Generate release notes
-      run: |
-        python ./utilities/release-notes.py ./ReleaseNotes.txt
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@master
       with:
-        files: ./ReleaseNotes.txt
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
As a temporary fix to get the publish workflow working this removes the steps to generate the release notes. Right now this [fails in CI](https://github.com/InsightSoftwareConsortium/itkwidgets/actions/runs/2928577942/jobs/4672916622#step:6:9) but succeeds when run locally. Issue #521 tracks this problem to be fixed.