### PR TITLE
COMP: Workaround Colab/Jupyter tornado dependency conflict for [all]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,9 +59,9 @@ Source = "https://github.com/InsightSoftwareConsortium/itkwidgets"
 
 [project.optional-dependencies]
 all = [
-    "imjoy-jupyterlab-extension >=0.1.13",
-    "imjoy-elfinder[jupyter]",
-    "imjoy-jupyter-extension >=0.3.0"
+    "imjoy-jupyterlab-extension >=0.1.13 ; python_version > '3.7'",
+    "imjoy-elfinder[jupyter] ; python_version > '3.7'",
+    "imjoy-jupyter-extension >=0.3.0 ; python_version > '3.7'"
 ]
 lab = [
     "imjoy-jupyterlab-extension >=0.1.13",


### PR DESCRIPTION
To make `pip install itkwidgets[all]` work in more situations out-of-the-box, only install the Jupyter related dependencies with Python version greater than 3.7 as a proxy for Google Colab. This works with the tools we have for dependency requirements and environments:

- https://hatch.pypa.io/latest/config/dependency/
- https://peps.python.org/pep-0508/

Google Colab has Python 3.7, not many other environments have it because it is deprecated.

The google-colab package requires tornado~=5.1.0, jupyter requires tornado>=6.2. 6.2 gets installed in Colab, and colab does not work.

This should be coupled with some ongoing work by @bnmajor to detect the running environment and throw an error if the required package dependencies are not installed for the case of Python 3.7 + Jupyter.