### PR TITLE
ENH: Bump viewer and UI to improve sliders

### DIFF
--- a/itkwidgets/viewer_config.py
+++ b/itkwidgets/viewer_config.py
@@ -1,5 +1,5 @@
 ITK_VIEWER_SRC = (
-    "https://bafybeid6yxdp43uiealcdbe2wrazmdeojc4pgee3gclhy76iiu5s37mg3q.on.fleek.co/"
+    "https://bafybeiancxmgdyuzu5k4v6jybk4fwach7rqwxc5gnkcw2u2q762sep7wre.on.fleek.co/"
 )
-PYDATA_SPHINX_HREF = "https://cdn.jsdelivr.net/npm/itk-viewer-bootstrap-ui@0.15.0/dist/bootstrapUIMachineOptions.js.es.js"
+PYDATA_SPHINX_HREF = "https://cdn.jsdelivr.net/npm/itk-viewer-bootstrap-ui@0.17.0/dist/bootstrapUIMachineOptions.js.es.js"
 MUI_HREF = "https://cdn.jsdelivr.net/npm/itk-viewer-material-ui@0.3.0/dist/materialUIMachineOptions.js.es.js"


### PR DESCRIPTION
- Annotations are now in upper right so that they are not covered by the plane sliders
- Plane sliders are now always shown even when the panel is collapsed