### PR TITLE
COMP: Limit traitlets to <5.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,6 @@ matplotlib
 numpy
 six
 zstandard
+traitlets<5.7.0
+notebook<6.5.0
+ipywidgets<8.0.0


### PR DESCRIPTION
To address #588:

> TraitError: label_image_weights shape expected to have 1 components, but got () components

We also have to explicitly install notebook, ipywidgets, because they are not installed via dependencies, and set them to versions compatible to traitslets 5.6.