### PR TITLE
Update to JupyterLite 0.1.0b17 and the `piplite_urls` config

### DIFF
--- a/docs/jupyterlite/jupyterlite_config.json
+++ b/docs/jupyterlite/jupyterlite_config.json
@@ -3,7 +3,9 @@
         "federated_extensions": [
             "https://files.pythonhosted.org/packages/15/ef/d7553d9968f317d02ee3e7819be5c9fc6cfa48e9fb3cf0cf92043c6a4205/imjoy_jupyterlab_extension-0.1.13-py3-none-any.whl"
         ],
-        "ignore_sys_prefix": true,
+        "ignore_sys_prefix": true
+    },
+    "PipliteAddon": {
         "piplite_urls": [
             "https://files.pythonhosted.org/packages/14/f7/ea85b5e4f59db353340543d450cd3d1c5befcde8bee0cc41a9de78fed82f/itkwasm-1.0b1-py3-none-any.whl",
             "https://files.pythonhosted.org/packages/6c/55/c3fc7e2b9671d15f0c0becdcb9fad6c330172988744ad6eaa17b71bace88/imjoy_rpc-0.5.16-py3-none-any.whl",

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 pydata-sphinx-theme
 myst-parser
-jupyterlite[all]
+jupyterlite[all]==0.1.0b17


### PR DESCRIPTION
With JupyterLite `0.1.0b17`, the `piplite_urls` configuration has changed and should now be put under the `PipliteAddon` field: https://github.com/jupyterlite/jupyterlite/releases/tag/v0.1.0b17

This change also pins to `jupyterlite[all]==0.1.0b17` for now to avoid catching potential breaking changes during the beta cycle.