### PR TITLE
BLD: Bump itk-vtk-viewer to version 14.27.0

### DIFF
--- a/itkwidgets/viewer_config.py
+++ b/itkwidgets/viewer_config.py
@@ -1,5 +1,5 @@
 ITK_VIEWER_SRC = (
-    "https://bafybeiancxmgdyuzu5k4v6jybk4fwach7rqwxc5gnkcw2u2q762sep7wre.on.fleek.co/"
+    "https://bafybeie7hafnugacze3kuj2dcgwys45a7s62m3fnfxsfokcz7s2su7ehwy.on.fleek.co/"
 )
 PYDATA_SPHINX_HREF = "https://cdn.jsdelivr.net/npm/itk-viewer-bootstrap-ui@0.17.0/dist/bootstrapUIMachineOptions.js.es.js"
 MUI_HREF = "https://cdn.jsdelivr.net/npm/itk-viewer-material-ui@0.3.0/dist/materialUIMachineOptions.js.es.js"


### PR DESCRIPTION
Use `itk-vtk-viewer` `v14.27.0` which now uses `vtk.js` `v25.15.1`