### PR TITLE
COMP: Init with fiji imagej

### DIFF
--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -29,7 +29,7 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install -e ".[test,all]"
           python3 -m pip install pyimagej
-          python3 -c "import imagej; ij = imagej.init('2.5.0'); print(ij.getVersion())"
+          python3 -c "import imagej; ij = imagej.init('sc.fiji:fiji:2.5.0'); print(ij.getVersion())"
           python3 -m pip install "itk>=5.3.0"
 
       - name: Test notebooks


### PR DESCRIPTION
To address:

```
Failed to bootstrap the artifact.

Possible solutions:
* Double check the endpoint for correctness (https://search.maven.org/).
* Add needed repositories to ~/.jgorc [repositories] block (see README).
* Try with an explicit version number (release metadata might be wrong).

Full Maven error output:
Error: R] Some problems were encountered while processing the POMs:
Error: ] Non-resolvable import POM: Could not transfer artifact net.imagej:imagej:pom:2.5.0 from/to scijava.public (https://maven.scijava.org/content/groups/public): transfer failed for https://maven.scijava.org/content/groups/public/net/imagej/imagej/2.5.0/imagej-2.5.0.pom @ line 8, column 29
Error: ] 'dependencies.dependency.version' for net.imagej:imagej-legacy:jar is missing. @ line 10, column 252
Error: ] 'dependencies.dependency.version' for org.scijava:scijava-config:jar is missing. @ line 10, column 462
Error: ] The build could not read 1 project -> [Help 1]
Error: ]
Error: ]   The project net.imagej-BOOTSTRAPPER:imagej-BOOTSTRAPPER:0 (/home/runner/.jgo/net.imagej/imagej/2.5.0/25280ba63ac2b82ba82d0e0126a26046929ed9f235535b7c20636efa1a51762f/pom.xml) has 3 errors
Error: ]     Non-resolvable import POM: Could not transfer artifact net.imagej:imagej:pom:2.5.0 from/to scijava.public (https://maven.scijava.org/content/groups/public): transfer failed for https://maven.scijava.org/content/groups/public/net/imagej/imagej/2.5.0/imagej-2.5.0.pom @ line 8, column 29: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target -> [Help 2]
Error: ]     'dependencies.dependency.version' for net.imagej:imagej-legacy:jar is missing. @ line 10, column 252
Error: ]     'dependencies.dependency.version' for org.scijava:scijava-config:jar is missing. @ line 10, column 462
Error: ]
Error: ] To see the full stack trace of the errors, re-run Maven with the -e switch.
Error: ] Re-run Maven using the -X switch to enable full debug logging.
Error: ]
Error: ] For more information about the errors and possible solutions, please read the following articles:
Error: ] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
Error: ] [Help 2] http://cwiki.apache.org/confluence/display/MAVEN/UnresolvableModelException
```

in CI.