### PR TITLE
TST: Disable testing for Python 3.11

### DIFF
--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -8,7 +8,7 @@ jobs:
     name: Test notebooks with nbmake
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Temporary fix to avoid issues with `wasmer-python` since they have no 3.11 wheels available.