### PR TITLE
BUG: Bump itkwasm dep to >= 1.0b.78 for Python 3.11 support

### DIFF
--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -8,7 +8,7 @@ jobs:
     name: Test notebooks with nbmake
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v3
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ keywords = [
 
 requires-python = ">=3.7"
 dependencies = [
-    "itkwasm >= 1.0.0-b.76",
+    "itkwasm >= 1.0b.78",
     "imjoy-rpc >= 0.5.16",
     "imjoy-utils >= 0.1.2",
     "importlib-metadata == 4.13.0 ; python_version == '3.7'",


### PR DESCRIPTION
Closes #619 