### PR TITLE
DOC: Add version query param to JupyterLite URL

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ powered by [itk-wasm](https://wasm.itk.org) and [ImJoy](https://imjoy.io/).
 *Welcome to The Future* 🔬🚀🛸!
 ```
 
-<a href="./_static/retro/notebooks/?path=Hello3DWorld.ipynb">
+<a href="./_static/retro/notebooks/?path=Hello3DWorld.ipynb&v=1.0a24">
 Try it with JupyterLite!
 
 ![Jupyterlite](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)


### PR DESCRIPTION
This attempts to add more cache refreshing so the latest version of the notebook / JupyterLite deployment is retrieved.

However, testing locally, it did provide an updated notebook for me with Chrome, npm's http-server.