### PR TITLE
BLD: Bump itk-vtk-viewer 14.35.0 -> 14.36.0

### DIFF
--- a/itkwidgets/viewer_config.py
+++ b/itkwidgets/viewer_config.py
@@ -1,5 +1,5 @@
 ITK_VIEWER_SRC = (
-    "https://bafybeigwv7wi3koqxjh6mzh5ycafltc2lpiqgzhj4j5qcr3d6lqsxy6oxe.on.fleek.co/"
+    "https://bafybeicx3a6ri4bjt5puhld6cby6o6ta4yhj5s5qmr6jbvegbh77cs2epi.on.fleek.co/"
 )
 PYDATA_SPHINX_HREF = "https://cdn.jsdelivr.net/npm/itk-viewer-bootstrap-ui@0.20.0/dist/bootstrapUIMachineOptions.js.es.js"
 MUI_HREF = "https://cdn.jsdelivr.net/npm/itk-viewer-material-ui@0.3.0/dist/materialUIMachineOptions.js.es.js"


### PR DESCRIPTION
Adds the following changes from itk-vtk-viewer:
- Handle TAKE_SCREENSHOT event: This should hopefully prevent the occasional "No object bound to API" error we were seeing in Colab notebooks
- do not clamp the color range