### PR TITLE
BLD: bump itk-vtk-viewer to always show compare swap image button

### DIFF
--- a/itkwidgets/viewer_config.py
+++ b/itkwidgets/viewer_config.py
@@ -1,5 +1,5 @@
 ITK_VIEWER_SRC = (
-    "https://bafybeibp3znmogg7kp4kujxioomg2h4jkp6caapwtal4im5jdcjndpj52q.on.fleek.co/"
+    "https://bafybeidvfjibujya47zn63mwfc2m4goasxobz6poyigtclyodmalakvmye.on.fleek.co/"
 )
-PYDATA_SPHINX_HREF = "https://cdn.jsdelivr.net/npm/itk-viewer-bootstrap-ui@0.21.0/dist/bootstrapUIMachineOptions.js.es.js"
+PYDATA_SPHINX_HREF = "https://cdn.jsdelivr.net/npm/itk-viewer-bootstrap-ui@0.22.0/dist/bootstrapUIMachineOptions.js.es.js"
 MUI_HREF = "https://cdn.jsdelivr.net/npm/itk-viewer-material-ui@0.3.0/dist/materialUIMachineOptions.js.es.js"


### PR DESCRIPTION
Move swap image toggle button next to the image mix slider:
![image](https://user-images.githubusercontent.com/16823231/234951943-36f7ac3a-8a75-44be-8aad-762bd310f2a1.png)


As suggested by @ebrahimebrahim
