### PR TITLE
ENH: Bump itk-vtk-viewer version 14.40.3 -> 14.41.1

### DIFF
--- a/itkwidgets/viewer_config.py
+++ b/itkwidgets/viewer_config.py
@@ -1,5 +1,5 @@
 ITK_VIEWER_SRC = (
-    "https://bafybeic7d6rwj3aegdced6ercvyqqqiwhe332vph4cy2pmkk5abmarxy4m.on.fleek.co/"
+    "https://bafybeieem7rb6gcni4hhqmesnfesrvqxdfo2ivqao4q72yskxxdrv2wvhu.on.fleek.co/"
 )
 PYDATA_SPHINX_HREF = "https://cdn.jsdelivr.net/npm/itk-viewer-bootstrap-ui@0.22.0/dist/bootstrapUIMachineOptions.js.es.js"
 MUI_HREF = "https://cdn.jsdelivr.net/npm/itk-viewer-material-ui@0.3.0/dist/materialUIMachineOptions.js.es.js"


### PR DESCRIPTION
Fixes the label image weighting so that only the label images are affected by changes and adds image mix animation.