### PR TITLE
BUG: Fix aiohttp dep for Python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,11 +61,13 @@ Source = "https://github.com/InsightSoftwareConsortium/itkwidgets"
 all = [
     "imjoy-jupyterlab-extension >=0.1.13",
     "imjoy-elfinder[jupyter]",
-    "imjoy-jupyter-extension >=0.3.0"
+    "imjoy-jupyter-extension >=0.3.0",
+    "aiohttp>=3.8.2; python_version=='3.11'"
 ]
 lab = [
     "imjoy-jupyterlab-extension >=0.1.13",
-    "imjoy-elfinder[jupyter]"
+    "imjoy-elfinder[jupyter]",
+    "aiohttp>=3.8.2; python_version=='3.11'"
 ]
 cli = [
     "hypha >= 0.15.28",
@@ -78,7 +80,8 @@ cli = [
 
 notebook = [
     "imjoy-jupyter-extension >=0.3.0",
-    "imjoy-elfinder[jupyter]"
+    "imjoy-elfinder[jupyter]",
+    "aiohttp>=3.8.2; python_version=='3.11'"
 ]
 test = [
     "pytest >=2.7.3",


### PR DESCRIPTION
As reported by @aylward: Trying to pip install --pre itkwidgets[all] produces an error when trying to compile aiohttp

The imjoy-elfinder dependency brings in aiohttp but <= 3.8.2 does not build for Python 3.11. For 3.11 make sure we use aiohttp>=3.8.2.

Stack Overflow [discussion](https://stackoverflow.com/questions/74550830/error-could-not-build-wheels-for-aiohttp-which-is-required-to-install-pyprojec) with links to relevant issues.