### PR TITLE
COMP: Fix imjoy_jupyterlab_extension module detection

### DIFF
--- a/itkwidgets/integrations/environment.py
+++ b/itkwidgets/integrations/environment.py
@@ -46,11 +46,14 @@ if ENVIRONMENT is not Env.JUPYTERLITE and ENVIRONMENT is not Env.HYPHA:
         else:
             try:
                 import_module("imjoy-jupyterlab-extension")
-            except:
-                if ENVIRONMENT is Env.JUPYTERLITE:
-                    raise RuntimeError('imjoy-jupyterlab-extension is required. Install the package and refresh page.')
-                elif sys.version_info.minor > 7:
-                    raise RuntimeError('imjoy-jupyterlab-extension is required. `pip install itkwidgets[lab]` and refresh page.')
+            except ModuleNotFoundError:
+                try:
+                    import_module("imjoy_jupyterlab_extension")
+                except ModuleNotFoundError:
+                    if ENVIRONMENT is Env.JUPYTERLITE:
+                        raise RuntimeError('imjoy-jupyterlab-extension is required. Install the package and refresh page.')
+                    elif sys.version_info.minor > 7:
+                        raise RuntimeError('imjoy-jupyterlab-extension is required. `pip install itkwidgets[lab]` and refresh page.')
 
     try:
         import imjoy_elfinder

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,9 +60,9 @@ Source = "https://github.com/InsightSoftwareConsortium/itkwidgets"
 
 [project.optional-dependencies]
 all = [
-    "imjoy-jupyterlab-extension >=0.1.13",
+    "imjoy-jupyterlab-extension ==0.1.13",
     "imjoy-elfinder[jupyter]",
-    "imjoy-jupyter-extension >=0.3.0",
+    "imjoy-jupyter-extension ==0.3.0",
     "aiohttp <4.0"
 ]
 lab = [


### PR DESCRIPTION
With the bump to 0.1.20, the module name changed to:

  imjoy_jupyterlab_extension

from:

  imjoy-jupyterlab-extension