### PR TITLE
ENH: register callback for saveRoi viewer event

### DIFF
--- a/itkwidgets/_initialization_params.py
+++ b/itkwidgets/_initialization_params.py
@@ -60,6 +60,7 @@ def build_config(ui=None):
     else:
         config = {}
     config['maxConcurrency'] = os.cpu_count() * 2
+    config['showSaveRoiButton'] = True
 
     return config
 

--- a/itkwidgets/viewer.py
+++ b/itkwidgets/viewer.py
@@ -82,6 +82,9 @@ class ViewerRPC:
                 itk_viewer.registerEventListener(
                     'screenshotTaken', self.update_screenshot
                 )
+                itk_viewer.registerEventListener(
+                    'saveRoi', self.save_roi
+                )
                 # Once the viewer has been created any queued requests can be run
                 CellWatcher().update_viewer_status(self.parent)
                 asyncio.get_running_loop().call_soon_threadsafe(self.viewer_event.set)
@@ -124,6 +127,9 @@ class ViewerRPC:
                 </script>
             ''')
         self.img.display(html)
+    
+    def save_roi(self, roi):
+        api.log(f'save roi {roi}')
 
     def set_event(self, event_data):
         # Once the data has been set the deferred queue requests can be run


### PR DESCRIPTION
Depends on https://github.com/Kitware/itk-vtk-viewer/pull/723

This is the `viewer_config.py` file I'm using to test:
```
ITK_VIEWER_SRC = (
    "http://localhost:8082"
)
PYDATA_SPHINX_HREF = "http://localhost:3000/dist/bootstrapUIMachineOptions.js.es.js"
MUI_HREF = "https://cdn.jsdelivr.net/npm/itk-viewer-material-ui@0.3.0/dist/materialUIMachineOptions.js.es.js"
```
