### PR TITLE
BUG: Bump JS viewer for label image background weight 0.0

### DIFF
--- a/itkwidgets/viewer_config.py
+++ b/itkwidgets/viewer_config.py
@@ -1,5 +1,5 @@
 ITK_VIEWER_SRC = (
-    "https://bafybeigzy333sj7clxyuhglkua2qnymooxqkvsm7rt6b5matx7dhvjv6wu.on.fleek.co/"
+    "https://bafybeicluuwk26eotnmcynvirwom2mqo5fmro5v3q43ptu7nsu3wgnwd3y.on.fleek.co/"
 )
 PYDATA_SPHINX_HREF = "https://cdn.jsdelivr.net/npm/itk-viewer-bootstrap-ui@0.28.0/dist/bootstrapUIMachineOptions.js.es.js"
 MUI_HREF = "https://cdn.jsdelivr.net/npm/itk-viewer-material-ui@0.3.0/dist/materialUIMachineOptions.js.es.js"


### PR DESCRIPTION
itk-vtk-viewer v14.46.1

Brings in https://github.com/Kitware/itk-vtk-viewer/pull/729 to address: https://github.com/InsightSoftwareConsortium/itkwidgets/issues/683