### PR TITLE
itk.image() to itk.output() in _type_aliases.py

### DIFF
--- a/itkwidgets/_type_aliases.py
+++ b/itkwidgets/_type_aliases.py
@@ -20,7 +20,7 @@ CroppingPlanes = {Literal['origin']: List[float], Literal['normal']: List[int]}
 
 if HAVE_ITK:
     import itk
-    Image = Union[Image, itk.Image]
+    Image = Union[Image, itk.output]
 if HAVE_VTK:
     import vtk
     Image = Union[Image, vtk.vtkImageData]


### PR DESCRIPTION
I'm not sure yet, as the whole itk module is currently not working for me... But meanwhile you might want to check if this line should be updated to match the fact that itk.image() is deprecated, and we should use itk.output() instead

https://github.com/InsightSoftwareConsortium/ITK/blob/2a1265d75f96ff7a072791629ff23b8c42123b3d/Wrapping/Generators/Python/itk/support/extras.py#L137