### PR TITLE
BUG: Add notebook>=7 as a dep for [notebook] installation option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,8 @@ cli = [
 
 notebook = [
     "imjoy-jupyterlab-extension",
-    "imjoy-elfinder[jupyter]"
+    "imjoy-elfinder[jupyter]",
+    "notebook >= 7"
 ]
 test = [
     "pytest >=2.7.3",


### PR DESCRIPTION
The `notebook` dependency no longer is brought in automatically. And
specify that we need notebook>=7 with our recent updates to
imjoy-jupyterlab-extension.
