### PR TITLE
BUG: Bump ngff-zarr dep to 0.8.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,8 @@ dependencies = [
     "imjoy-rpc >= 0.5.42",
     "imjoy-utils >= 0.1.2",
     "importlib_metadata",
-    "ngff-zarr >= 0.8.1; sys_platform != \"emscripten\"",
-    "ngff-zarr[dask-image] >= 0.8.1; sys_platform == \"emscripten\"",
+    "ngff-zarr >= 0.8.2; sys_platform != \"emscripten\"",
+    "ngff-zarr[dask-image] >= 0.8.2; sys_platform == \"emscripten\"",
     "numcodecs",
     "zarr",
 ]


### PR DESCRIPTION
Add support for more label image downsample types, encountered with
torch / monai, via:

  https://github.com/InsightSoftwareConsortium/itk-wasm/pull/1117/commits/ffb6e2cf6c8b5c3f064c16d5d51636cd85a59eae
