### PR TITLE
BUG: point viewer URL to github host

### DIFF
--- a/itkwidgets/viewer_config.py
+++ b/itkwidgets/viewer_config.py
@@ -1,5 +1,5 @@
 ITK_VIEWER_SRC = (
-    "https://bafybeieiqiiwvdq66e2bndws5nwojbe4wwerbxyua6u37axxivi2rwf7wy.on.fleek.co/"
+    "https://kitware.github.io/itk-vtk-viewer/app/"
 )
 PYDATA_SPHINX_HREF = "https://cdn.jsdelivr.net/npm/itk-viewer-bootstrap-ui@0.30.0/dist/bootstrapUIMachineOptions.js.es.js"
 MUI_HREF = "https://cdn.jsdelivr.net/npm/itk-viewer-material-ui@0.3.0/dist/materialUIMachineOptions.js.es.js"


### PR DESCRIPTION
This is a tempoary solution as we should pin the JavaScript client version to the pypi version.

Closes #766

