### PR TITLE
BUG: Move from on.fleek.co to dweb.link gateway

### DIFF
--- a/.github/workflows/notebook-test.yml
+++ b/.github/workflows/notebook-test.yml
@@ -8,7 +8,7 @@ jobs:
     name: Test notebooks with nbmake
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9']
     steps:
       - uses: actions/checkout@v3
         with:
@@ -33,11 +33,5 @@ jobs:
           python3 -m pip install "itk>=5.3.0"
 
       - name: Test notebooks
-        if: ${{ matrix.python-version != '3.8' }}
         run: |
           pytest --nbmake --nbmake-timeout=3000 examples/EnvironmentCheck.ipynb examples/Hello3DWorld.ipynb examples/NumPyArrayPointSet.ipynb examples/integrations/**/*.ipynb
-
-      - name: Test notebooks
-        if: ${{ matrix.python-version == '3.8' }}
-        run: |
-          pytest --nbmake --nbmake-timeout=3000 examples/Hello3DWorld.ipynb examples/NumPyArrayPointSet.ipynb examples/integrations/**/*.ipynb

--- a/itkwidgets/standalone/index.html
+++ b/itkwidgets/standalone/index.html
@@ -25,7 +25,7 @@
 
   <body>
     <div class="content" style="position: absolute; width: 100vw; height: 100vh; top: 0; left: 0; overflow: hidden; background: black; margin: 0; padding: 0;"></div>
-    <script type="text/javascript" src="https://bafybeiauuswm657tct7b7kpnorrsz7hvvaljpsbeuw35hkfobtyyrbblpm.on.fleek.co/itkVtkViewer.js">    </script>
+    <script type="text/javascript" src="https://bafybeiauuswm657tct7b7kpnorrsz7hvvaljpsbeuw35hkfobtyyrbblpm.ipfs.dweb.link/itkVtkViewer.js">    </script>
     <script>
     async function setupHypha(config) {
         globalThis.config = config

--- a/itkwidgets/viewer_config.py
+++ b/itkwidgets/viewer_config.py
@@ -1,5 +1,5 @@
 ITK_VIEWER_SRC = (
-    "https://bafybeieiqiiwvdq66e2bndws5nwojbe4wwerbxyua6u37axxivi2rwf7wy.on.fleek.co/"
+    "https://bafybeieiqiiwvdq66e2bndws5nwojbe4wwerbxyua6u37axxivi2rwf7wy.ipfs.dweb.link/"
 )
 PYDATA_SPHINX_HREF = "https://cdn.jsdelivr.net/npm/itk-viewer-bootstrap-ui@0.30.0/dist/bootstrapUIMachineOptions.js.es.js"
 MUI_HREF = "https://cdn.jsdelivr.net/npm/itk-viewer-material-ui@0.3.0/dist/materialUIMachineOptions.js.es.js"


### PR DESCRIPTION
Fleek made a major transition to new infrastructure, their fleek.co
gateway is no longer available.

Move to the Protocol Labs public dweb.link gateway.

These CID's were also pinned on Pinata.
